### PR TITLE
Fixes for issues spotted on 2022-06-09

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -42,7 +42,7 @@
 }
 
 #' @export
-.emo <- function(x = c("info", "practice", "proof", "goal", "nerd", "party", "broken", "slow", "warn", "alien")) {
+.emo <- function(x = c("info", "practice", "proof", "goal", "nerd", "party", "broken", "slow", "warn", "alien", "recap")) {
   x <- match.arg(x)
   if (!requireNamespace("emojifont")) stop("You need to install the package emojifont to use this function.")
   switch(x,
@@ -55,6 +55,7 @@
     broken = emojifont::emoji("angry"),
     slow = emojifont::emoji("fire"),
     warn = emojifont::emoji("warning"),
-    alien = emojifont::emoji("alien")
+    alien = emojifont::emoji("alien"),
+    recap = emojifont::emoji("rewind")
   )
 }

--- a/vignettes/Introduction_course.Rmd
+++ b/vignettes/Introduction_course.Rmd
@@ -50,6 +50,7 @@ I may also use a few others within the slides
 - `r .emo("broken")` for things that are broken
 - `r .emo("slow")` for heavy computations
 - `r .emo("warn")` for warnings
+- `r .emo("recap")` recap something we covered previously
 
 ## Course philosophy `r .emo("info")`
 

--- a/vignettes/LM_fitting_course.Rmd
+++ b/vignettes/LM_fitting_course.Rmd
@@ -643,7 +643,7 @@ solve(t(X) %*% X) %*% t(X) %*% Y  ## Tip: solve(x) returns the inverse of the ma
 Geek note: $\widehat{Y} = X \widehat{\beta} = X (X^TX)^{-1}X^TY=HY$, and $H$ is called the hat matrix (it is a projection matrix and it can be used for various purposes).
 
 
-## `lm()`-like fitting using QR decomposition `r .emo("info")`
+## `lm()`-like fitting using QR decomposition `r .emo("nerd")`
 
 The goal is simply to decompose the design matrix into a product of two new matrices that present nice properties for doing maths super efficiently.
 
@@ -667,7 +667,7 @@ backsolve(R, QTY) ## solve B from RB = QTY
 * Note 2: other decompositions are sometimes used in other packages or other type of linear models (e.g. Cholesky decomposition).
 
 
-## Actual `lm()` fitting procedure `r .emo("info")`
+## Actual `lm()` fitting procedure `r .emo("nerd")`
 
 First, `lm()` processes information for `lm.fit()`; it is quite a difficult function to read but here are the important steps:
 ```{r lm guts, eval = FALSE}

--- a/vignettes/LM_intro_course.Rmd
+++ b/vignettes/LM_intro_course.Rmd
@@ -791,12 +791,16 @@ It produces a symmetric diagonal matrix. Those are particularly maths friendly.
 -->
 
 ## A design matrix with > 1 factors `r .emo("practice")`
-
 ```{r factorial}
 model.matrix(object = ~ planet + sex, data = Alien2)
 ```
 Now the intercept corresponds to observations that have the first level for all factors.
 
+## A design matrix with > 1 factors `r .emo("practice")`
+
+```{r factorial coef}
+lm(age ~ planet + sex, data = Alien2)
+```
 
 ## A design matrix with interactions `r .emo("practice")`
 

--- a/vignettes/LM_intro_course.Rmd
+++ b/vignettes/LM_intro_course.Rmd
@@ -431,6 +431,8 @@ my_palette <- c("#f06543", "#ddd92a", "#7371fc")
 
 library(ggplot2)
 ggplot(data = Alien) +
+  geom_point(aes(x = humans_eaten, y = size, colour = "Observed value"),
+             shape = 4, size = 1, stroke = 2) +
   geom_segment(aes(x = 0, xend = humans_eaten, y = size_mean, yend = size_mean),
                lty = 2) +
   geom_segment(aes(x = humans_eaten, xend = humans_eaten, y = size_mean, yend = 45),
@@ -441,8 +443,6 @@ ggplot(data = Alien) +
              size = 2) +
   geom_point(aes(x = humans_eaten, y = size_fitted, colour = "Fitted value"),
              size = 2) +
-  geom_point(aes(x = humans_eaten, y = size),
-             shape = 4, size = 2, stroke = 2, colour = "blue") +
   ### ADD CURVED ARROWS THAT POINT TO IMPORTANT VALUES
   geom_curve(data = label_data,
              aes(x = x, xend = xend, y = y, yend = yend, colour = label),
@@ -892,6 +892,115 @@ The variance of the error ($\sigma^2$) cannot be directly observed...
 ... but it can be estimated from the variance of the residual.
 
 <br>
+
+## The residuals `r .emo("practice")`
+
+```{r}
+mod_intercept <- coef(fit_alien_lm)[["(Intercept)"]]
+mod_slope     <- coef(fit_alien_lm)[["humans_eaten"]]
+
+#Data for mean and fitted lines
+line_data <- data.frame(humans_eaten = rep(c(0, 3), times = 2),
+                        var = rep(c("Mean response\nvalue", "Fitted value"), each = 2))
+line_data$size <- ifelse(line_data$var == "Mean response\nvalue",
+                         50 + line_data$humans_eaten*1.5,
+                         mod_intercept + line_data$humans_eaten*mod_slope)
+
+#Line and text data
+label_data <- data.frame(label = c("Observed value",
+                                   "Fitted value",
+                                   "Mean response\nvalue",
+                                   "Error",
+                                   "Residual"),
+                         x = c(3.5, 3.5, 3.5, 1.7, 2.3),
+                         xend = c(3.05, 3.05, 3.05, 1.9, 2.1),
+                         y = c(59.5, 56.5, 52.5, Alien[3, "size"] + 1, Alien[3, "size"] + 1),
+                         yend = c(Alien[nrow(Alien), "size"] + 0.2,
+                                  Alien[nrow(Alien), "size_fitted"],
+                                  Alien[nrow(Alien), "size_mean"],
+                                  Alien[3, "size"] - 1,
+                                  Alien[3, "size"] - 1))
+
+#Palette
+my_palette <- c("#3a405a", "#f06543", "#ddd92a", "#7371fc", "#20BF55")
+
+
+library(ggplot2)
+ggplot(data = Alien) +
+  ### ADD POINTS SHOWING OBSERVED VALUES
+  geom_point(aes(x = humans_eaten, y = size, colour = "Observed value"),
+             shape = 4, size = 1, stroke = 2) +
+  geom_segment(aes(x = 0, xend = humans_eaten, y = size_mean, yend = size_mean),
+               lty = 2) +
+  geom_segment(aes(x = humans_eaten, xend = humans_eaten, y = size_mean, yend = 45),
+               lty = 2) +
+  geom_line(data = line_data, aes(x = humans_eaten, y = size, colour = var),
+            size = 1) +
+  geom_point(aes(x = humans_eaten, y = size_mean, colour = "Mean response\nvalue"),
+             size = 2) +
+  geom_point(aes(x = humans_eaten, y = size_fitted, colour = "Fitted value"),
+             size = 2) +
+  ### ADD SEGMENTS TO SHOW RESIDUALS V. ERRORS
+  #### ERROR SEGMENTS
+  geom_segment(data = Alien[3, ], aes(xend = humans_eaten, x = humans_eaten - 0.05,
+                                      y = size - 0.02, yend = size - 0.02, colour = "Error"),
+               size = 1) +
+  geom_segment(data = Alien[3, ], aes(xend = humans_eaten, x = humans_eaten - 0.05,
+                                      y = size_mean + 0.02, yend = size_mean + 0.02, colour = "Error"),
+               size = 1) +
+  geom_segment(data = Alien[3, ], aes(x = humans_eaten - 0.05, xend = humans_eaten - 0.05, y = size, yend = size_mean,
+                                      colour = "Error"),
+               lty = 1, size = 1) +
+  #### RESIDUAL SEGMENTS
+    geom_segment(data = Alien[3, ], aes(xend = humans_eaten, x = humans_eaten + 0.05,
+                                      y = size - 0.02, yend = size - 0.02, colour = "Residual"),
+               size = 1) +
+  geom_segment(data = Alien[3, ], aes(xend = humans_eaten, x = humans_eaten + 0.05,
+                                      y = size_fitted + 0.02, yend = size_fitted + 0.02, colour = "Residual"),
+               size = 1) +
+  geom_segment(data = Alien[3, ], aes(x = humans_eaten + 0.05, xend = humans_eaten + 0.05, y = size, yend = size_fitted, 
+                                      colour = "Residual"),
+               lty = 1, size = 1) +
+  ### ADD CURVED ARROWS THAT POINT TO IMPORTANT VALUES
+  geom_curve(data = label_data[1:3, ],
+             aes(x = x, xend = xend, y = y, yend = yend, colour = label),
+             curvature = 0.15, arrow = arrow(length = unit(0.3, units = "cm"))) +
+  geom_curve(data = label_data[4, ],
+             aes(x = x, xend = xend, y = y, yend = yend, colour = label),
+             curvature = 0.15, arrow = arrow(length = unit(0.3, units = "cm"))) +
+  geom_curve(data = label_data[5, ],
+             aes(x = x, xend = xend, y = y, yend = yend, colour = label),
+             curvature = -0.15, arrow = arrow(length = unit(0.3, units = "cm"))) +
+  ### ADD TEXT TO LABELS
+  geom_text(data = label_data[1:3, ],
+            aes(x = x, y = y, label = label, colour = label),
+            hjust = 0, vjust = 0.75) +
+  geom_text(data = label_data[4:5, ],
+            aes(x = x, y = y + 0.2, label = label, colour = label),
+            hjust = 0.5, vjust = 0.5) +
+  scale_colour_manual(values = my_palette) +
+  scale_x_continuous(limits = c(0, 4.25),
+                     breaks = 0:3,
+                     labels = c(0, 1, 2, 3),
+                     expand = c(0, 0)) +
+  scale_y_continuous(limits = c(45, 60),
+                     breaks = c(45, mod_intercept, 50, 51.5, 53.0, 54.5, 60),
+                     labels = c("45.0",
+                                paste0("Intercept estimate --> ", signif(mod_intercept, 3)),
+                                "Intercept -->  50.0",
+                                "51.5", "53.0", "54.5", "60.0"),
+                     expand = c(0, 0)) +
+  labs(x = "Humans eaten", y = "Size") +
+  theme_classic() +
+  theme(legend.position = "none",
+        axis.title.y = element_text(vjust = -25),
+        plot.background = element_blank(),
+        panel.background = element_blank(),
+        axis.title = element_text(size = 20, colour = "black"),
+        axis.text = element_text(size = 12, colour = "black"),
+        axis.ticks = element_line(colour = "black"),
+        plot.margin = margin(t = 10, r = 10, b = 10, l = 10))
+```
 
 ## Interlude: estimation of variances `r .emo("info")`
 

--- a/vignettes/LM_intro_course.Rmd
+++ b/vignettes/LM_intro_course.Rmd
@@ -643,20 +643,6 @@ This parametrization of factors such as `planet` follows the so-called matrix of
 
 It is the easiest one to interpret and the one used by default in R (but not in all software).
 
-
-## Interpreting the treatment contrasts `r .emo("info")`
-
-```{r treatment contrast}
-model.matrix(object = ~ planet, data = Alien2)
-```
-
-* The intercept represents the mean response value for the baseline (here, reference level = ```"Chambr"```).
-* ```planetRiplyx``` represents the mean response value for ```"Riplyx"``` minus the mean of the baseline.
-* ```planetWickor``` represents the mean response value for ```"Wickor"``` minus the mean of the baseline.
-
-Note: in base R the default level of reference is always the first level of a factor. Which level comes first can be changed, but by default it is the first level when ranked by alphabetical order given the locale (mind that `forcats::as_factor()` behave differently than `as.factor()`; the forcats function follows order in which levels appear).
-
-
 ## A design matrix with a factor `r .emo("practice")`
 
 ```{r factor 2}
@@ -670,6 +656,17 @@ D <- model.matrix(object = ~ planet, data = Alien2) ## same as D <- model.matrix
 cbind(D, data.frame(fitted = D %*% coef(fit_alien_lm2))) ## same as fitted = fitted.values(fit_alien_lm2)
 ```
 
+## Interpreting the treatment contrasts `r .emo("info")`
+
+```{r treatment contrast}
+model.matrix(object = ~ planet, data = Alien2)
+```
+
+* The intercept represents the mean response value for the baseline (here, reference level = ```"Chambr"```).
+* ```planetRiplyx``` represents the mean response value for ```"Riplyx"``` minus the mean of the baseline.
+* ```planetWickor``` represents the mean response value for ```"Wickor"``` minus the mean of the baseline.
+
+Note: in base R the default level of reference is always the first level of a factor. Which level comes first can be changed, but by default it is the first level when ranked by alphabetical order given the locale (mind that `forcats::as_factor()` behave differently than `as.factor()`; the forcats function follows order in which levels appear).
 
 ## There are alternative parametrizations! `r .emo("warn")`
 

--- a/vignettes/LM_intro_course.Rmd
+++ b/vignettes/LM_intro_course.Rmd
@@ -924,8 +924,6 @@ label_data <- data.frame(label = c("Observed value",
 #Palette
 my_palette <- c("#3a405a", "#f06543", "#ddd92a", "#7371fc", "#20BF55")
 
-
-library(ggplot2)
 ggplot(data = Alien) +
   ### ADD POINTS SHOWING OBSERVED VALUES
   geom_point(aes(x = humans_eaten, y = size, colour = "Observed value"),

--- a/vignettes/LM_intro_course.Rmd
+++ b/vignettes/LM_intro_course.Rmd
@@ -895,7 +895,7 @@ The variance of the error ($\sigma^2$) cannot be directly observed...
 
 ## The residuals `r .emo("practice")`
 
-```{r}
+```{r fig.height=5, fig.width=10, echo = FALSE}
 mod_intercept <- coef(fit_alien_lm)[["(Intercept)"]]
 mod_slope     <- coef(fit_alien_lm)[["humans_eaten"]]
 

--- a/vignettes/LM_intro_course.Rmd
+++ b/vignettes/LM_intro_course.Rmd
@@ -668,6 +668,25 @@ model.matrix(object = ~ planet, data = Alien2)
 
 Note: in base R the default level of reference is always the first level of a factor. Which level comes first can be changed, but by default it is the first level when ranked by alphabetical order given the locale (mind that `forcats::as_factor()` behave differently than `as.factor()`; the forcats function follows order in which levels appear).
 
+## Interpreting the treatment contrasts `r .emo("info")`
+
+```{r refactor 1}
+Alien2$planet <- factor(Alien2$planet, levels = c("Riplyx", "Chambr", "Wickor")) #Change reference to 'Riplyx'
+(fit_alien_lm_revel <- lm(age ~ planet, data = Alien2)) #Different regression coefficients
+```
+
+Regression coefficients are different, but fitted values are unchanged!
+
+```{r refactor 2}
+D <- model.matrix(object = ~ planet, data = Alien2)
+cbind(D, data.frame(fitted = D %*% coef(fit_alien_lm2)))
+```
+
+```{r, echo = FALSE}
+#Relevel to make sure following code still works
+Alien2$planet <- factor(Alien2$planet, levels = c("Chambr", "Riplyx", "Wickor"))
+```
+
 ## There are alternative parametrizations! `r .emo("warn")`
 
 ```{r sum contrast 1}

--- a/vignettes/LM_intro_course.Rmd
+++ b/vignettes/LM_intro_course.Rmd
@@ -682,7 +682,7 @@ D <- model.matrix(object = ~ planet, data = Alien2)
 cbind(D, data.frame(fitted = D %*% coef(fit_alien_lm2)))
 ```
 
-```{r, echo = FALSE}
+```{r, include = FALSE}
 #Relevel to make sure following code still works
 Alien2$planet <- factor(Alien2$planet, levels = c("Chambr", "Riplyx", "Wickor"))
 ```

--- a/vignettes/LM_test_intervals_course.Rmd
+++ b/vignettes/LM_test_intervals_course.Rmd
@@ -92,6 +92,47 @@ fit_lm_UK1 <- lm(height ~ drink + sex*weight, data = UK)
 fit_lm_UK1
 ```
 
+## RECAP: Interpreting regression coefficients `r .emo("info")`
+
+```{r Britons fit lm2, echo = FALSE}
+fit_lm_UK1
+```
+
+<br>
+
+How do you interpret each parameter estimate?
+
+## RECAP: Interpreting regression coefficients `r .emo("info")`
+
+```{r interaction_plot, echo = FALSE, fig.width = 5}
+#Plot interaction effect of sex:weight at reference level of drink
+plot_data <- expand.grid(drink = c("2 to 3 times a week"),
+                         sex = c("Girl", "Boy"),
+                         weight = c(0, 50))
+plot_data$height <- predict(fit_lm_UK1, newdata = plot_data)
+library(ggplot2)
+ggplot(plot_data) +
+  geom_line(aes(x  = weight, y = height, colour = sex), size = 1) +
+  geom_text(data = plot_data[plot_data$weight == 50, ],
+            aes(x = weight - 4, y = height * c(0.95, 1.01), colour = sex, label = c("\U2640", "\U2642")),
+            size = 10) +
+  scale_x_continuous(expand = c(0, 0)) +
+  scale_y_continuous(limits = c(110, 160),
+                     breaks = c(fit_lm_UK1$coefficients["(Intercept)"],
+                                fit_lm_UK1$coefficients["(Intercept)"] + fit_lm_UK1$coefficients["sexGirl"],
+                                120, 130, 140, 150, 160),
+                     labels = c(format(as.numeric(fit_lm_UK1$coefficients["(Intercept)"]), digits = 5),
+                                format(as.numeric(fit_lm_UK1$coefficients["(Intercept)"] + fit_lm_UK1$coefficients["sexGirl"]), digits = 5),
+                                "120", "130", "140", "150", "160")) +
+  scale_colour_manual(values = c("#41658A", "#70A37F")) +
+  labs(x = "Weight (kg)",
+       y = "Height (cm)",
+       title = "Relationship between weight and height for\nthe reference level of 'drink'") +
+  theme_classic() +
+  theme(legend.position = "none",
+        axis.text = element_text(colour = "black"),
+        axis.ticks = element_line(colour = "black"))
+```
 
 ## Britons fitted with `spaMM::fitme()` `r .emo("alien")`
 

--- a/vignettes/LM_test_intervals_course.Rmd
+++ b/vignettes/LM_test_intervals_course.Rmd
@@ -92,12 +92,6 @@ fit_lm_UK1 <- lm(height ~ drink + sex*weight, data = UK)
 fit_lm_UK1
 ```
 
-## RECAP: Interpreting regression coefficients `r .emo("recap")`
-
-```{r Britons fit lm2, echo = FALSE}
-fit_lm_UK1
-```
-
 <br>
 
 How do you interpret each parameter estimate?

--- a/vignettes/LM_test_intervals_course.Rmd
+++ b/vignettes/LM_test_intervals_course.Rmd
@@ -92,7 +92,7 @@ fit_lm_UK1 <- lm(height ~ drink + sex*weight, data = UK)
 fit_lm_UK1
 ```
 
-## RECAP: Interpreting regression coefficients `r .emo("info")`
+## RECAP: Interpreting regression coefficients `r .emo("recap")`
 
 ```{r Britons fit lm2, echo = FALSE}
 fit_lm_UK1
@@ -102,7 +102,7 @@ fit_lm_UK1
 
 How do you interpret each parameter estimate?
 
-## RECAP: Interpreting regression coefficients `r .emo("info")`
+## RECAP: Interpreting regression coefficients `r .emo("recap")`
 
 ```{r interaction_plot, echo = FALSE, fig.width = 5}
 #Plot interaction effect of sex:weight at reference level of drink


### PR DESCRIPTION
Includes:
- Switch order of slides for interpreting treatment contrasts (Fix #35)
- Demonstrate difference in design matrix when we relevel factors (Fix #36)
- Add slide showing regression co-efficients when we have two categorical variables (Fix #37)
- Label QR decomposition with 🤓 (Fix #40)
- Add plot showing difference between residuals and error (Fix #39)
- Add plot demonstrating interaction between categorical and continuous variables (#38).
- Add new emoji ⏪ to highlight slides that recap past concepts.

Following discussion on #38, this is currently included in LM_test_intervals_course.Rmd as a 'recap' slide. We could include it also in LM_intro_course.Rmd but would need to change effect size of planet:bh_trips.